### PR TITLE
Add deployment contract and update deployment script

### DIFF
--- a/deployment/0_deployInitialize.sh
+++ b/deployment/0_deployInitialize.sh
@@ -1,0 +1,2 @@
+# deploy to tenderly mainnet fork network
+forge script script/DeployAndInitialize.s.sol:DeployerScript --broadcast --verify --rpc-url https://rpc.tenderly.co/fork/cc2b5331-1bfa-4756-84ab-e2f2f63a91d5

--- a/deployment/1_verify.sh
+++ b/deployment/1_verify.sh
@@ -1,0 +1,2 @@
+# deploy to tenderly mainnet fork network
+forge script script/verifyDeployment.s.sol:VerifyDeployment --broadcast --verify --rpc-url https://rpc.tenderly.co/fork/cc2b5331-1bfa-4756-84ab-e2f2f63a91d5

--- a/script/DeployAndInitialize.s.sol
+++ b/script/DeployAndInitialize.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "forge-std/Script.sol";
+import "../src/InverseBondingCurve.sol";
+import "../src/InverseBondingCurveProxy.sol";
+import "../src/InverseBondingCurveToken.sol";
+import "../src/Deployer.sol";
+import "forge-std/console2.sol";
+
+contract DeployerScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        // Put secret in .secret file under contracts folder
+        string memory seedPhrase = vm.readFile(".secret");
+        uint256 privateKey = vm.deriveKey(seedPhrase, 0);
+        vm.startBroadcast(privateKey);
+        address feeOwner = vm.addr(privateKey);
+
+        uint256 virtualReserve = 2e18;
+        uint256 supply = 1e18;
+        uint256 price = 1e18;
+
+        Deployer deployer = new Deployer();
+
+        deployer.deploy(
+            type(InverseBondingCurve).creationCode,
+            type(InverseBondingCurveToken).creationCode,
+            type(InverseBondingCurveProxy).creationCode,
+            virtualReserve,
+            supply,
+            price,
+            feeOwner
+        );
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/VerifyDeployment.s.sol
+++ b/script/VerifyDeployment.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "forge-std/Script.sol";
+import "../src/InverseBondingCurve.sol";
+import "../src/InverseBondingCurveProxy.sol";
+import "../src/InverseBondingCurveToken.sol";
+import "../src/Deployer.sol";
+import "forge-std/console2.sol";
+
+contract VerifyDeployment is Script {
+    function setUp() public {}
+
+
+    function run() public {
+        // Put secret in .secret file under contracts folder
+        string memory seedPhrase = vm.readFile(".secret");
+        uint256 privateKey = vm.deriveKey(seedPhrase, 0);
+        vm.startBroadcast(privateKey);
+        address feeOwner = vm.addr(privateKey);
+        
+        uint256 virtualReserve = 2e18;
+        uint256 supply = 1e18;
+
+        Deployer deployer = Deployer(vm.parseAddress("0x1d460d731bd5a0ff2ca07309daeb8641a7b175a1"));
+
+        (address curveContractAddress, address tokenContractAddress, address proxyContractAddress) = deployer.getDeployedContracts();
+
+        console2.log("Inverse bonding curve implementation contract address:", curveContractAddress);
+        console2.log("Inverse bonding curve token contract address:", tokenContractAddress);
+        console2.log("Inverse bonding curve proxy contract address:", proxyContractAddress);
+
+        InverseBondingCurve curveContract = InverseBondingCurve(proxyContractAddress);
+        InverseBondingCurveToken tokenContract = InverseBondingCurveToken(tokenContractAddress);
+
+        CurveParameter memory param = curveContract.curveParameters();
+        require(curveContract.owner() == vm.addr(privateKey), "Curve contract owner incorrect");
+        require(tokenContract.owner() == proxyContractAddress, "Token contract owner incorrect");
+        require(curveContract.getImplementation() == curveContractAddress, "Curve implementation incorrect");
+
+        require(param.virtualReserve == virtualReserve, "Reserve Parameter incorrect");
+        require(param.virtualSupply == supply, "Supply Parameter incorrect");
+        require(param.virtualSupply == supply, "Supply Parameter incorrect");
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/Deployer.sol
+++ b/src/Deployer.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "openzeppelin/access/Ownable.sol";
+import "openzeppelin/utils/Create2.sol";
+
+contract Deployer is Ownable {
+    event Deployed(address cruveContract, address tokenContract, address proxyContract);
+
+    address _cruveContract;
+    address _proxyContract;
+    address _tokenContract;
+
+    constructor() Ownable() {}
+
+    function deploy(
+        bytes memory curveContractCode,
+        bytes memory tokenContractCode,
+        bytes memory proxyContractCode,
+        uint256 virtualReserve,
+        uint256 supply,
+        uint256 price,
+        address protocolFeeOwner
+    ) external onlyOwner{
+        bytes32 salt = bytes32(uint256(uint160(msg.sender)) + block.number);
+        _cruveContract = Create2.deploy(0, salt, abi.encodePacked(curveContractCode));
+
+        bytes memory creationCode = abi.encodePacked(tokenContractCode, abi.encode(address(this), "IBC", "IBC"));
+        _tokenContract = Create2.deploy(0, salt, creationCode);
+
+        // Create proxy contract and intialize
+        bytes memory data = abi.encodeWithSignature(
+            "initialize(uint256,uint256,uint256,address,address)",
+            virtualReserve,
+            supply,
+            price,
+            _tokenContract,
+            protocolFeeOwner
+        );
+        creationCode = abi.encodePacked(proxyContractCode, abi.encode(_cruveContract, data));
+        _proxyContract = Create2.deploy(0, salt, creationCode);
+
+        // Change owner to external owner
+        (bool success,) = _tokenContract.call(abi.encodeWithSignature("transferOwnership(address)", _proxyContract));
+        require(success, "Token contract owner transfer failed");
+
+        (success,) = _proxyContract.call(abi.encodeWithSignature("transferOwnership(address)", owner()));
+        require(success, "Token contract owner transfer failed");
+
+        emit Deployed(_cruveContract, _tokenContract, _proxyContract);
+    }
+
+    function getDeployedContracts() external view returns (address cruveContract, address proxyContract, address tokenContract) {
+        return (_cruveContract, _tokenContract, _proxyContract);
+    }
+}

--- a/src/InverseBondingCurve.sol
+++ b/src/InverseBondingCurve.sol
@@ -56,8 +56,8 @@ contract InverseBondingCurve is
         uint256 newParameterInvariant
     );
 
-    event LiquidityStaked(address indexed from, uint256 amount);
-    event LiquidityUnstaked(address indexed from, uint256 amount);
+    event TokenStaked(address indexed from, uint256 amount);
+    event TokenUnstaked(address indexed from, uint256 amount);
 
     event TokenBought(address indexed from, address indexed recipient, uint256 amountIn, uint256 amountOut);
 
@@ -284,7 +284,7 @@ contract InverseBondingCurve is
         _totalStaked += amount;
         IERC20(_inverseToken).safeTransferFrom(msg.sender, address(this), amount);
 
-        emit LiquidityStaked(msg.sender, amount);
+        emit TokenStaked(msg.sender, amount);
     }
 
     function unstake(uint256 amount) external whenNotPaused {
@@ -295,7 +295,7 @@ contract InverseBondingCurve is
         _totalStaked -= amount;
         IERC20(_inverseToken).safeTransfer(msg.sender, amount);
 
-        emit LiquidityUnstaked(msg.sender, amount);
+        emit TokenUnstaked(msg.sender, amount);
     }
 
     function claimReward(address recipient) external whenNotPaused {

--- a/test/InverseBondingCurve.t.sol
+++ b/test/InverseBondingCurve.t.sol
@@ -131,7 +131,7 @@ contract InverseBondingCurveTest is Test {
         vm.expectRevert(bytes(ERR_EMPTY_ADDRESS));
         curveContract.updateFeeOwner(address(0));
         vm.stopPrank();
-    } 
+    }
 
     function testUpdateFeeOwner() public {
         vm.startPrank(owner);
@@ -145,7 +145,7 @@ contract InverseBondingCurveTest is Test {
         vm.startPrank(nonOwner);
         curveContract.claimProtocolReward();
         vm.stopPrank();
-    }        
+    }
 
     function testPause() public {
         curveContract.addLiquidity{value: 1 ether}(recipient, 1e18);
@@ -209,7 +209,6 @@ contract InverseBondingCurveTest is Test {
         curveContract.addLiquidity{value: LIQUIDITY_2ETH_BEFOR_FEE}(recipient, 1e18);
 
         uint256 balanceBefore = otherRecipient.balance;
-
 
         uint256 lpAmount = curveContract.balanceOf(recipient);
 
@@ -280,7 +279,6 @@ contract InverseBondingCurveTest is Test {
         uint256 balanceBefore = tokenContract.balanceOf(otherRecipient);
         curveContract.claimReward(otherRecipient);
         uint256 balanceAfter = tokenContract.balanceOf(otherRecipient);
-
 
         assertEqWithError(feeBalance, (balanceAfter - balanceBefore) * 3);
         assertEqWithError(tokenContract.balanceOf(address(curveContract)), feeBalance - (balanceAfter - balanceBefore));
@@ -360,7 +358,6 @@ contract InverseBondingCurveTest is Test {
 
         assert(firstSellFee + secondSellFee - otherRecipientFee < ALLOWED_ERROR);
         assert(secondSellFeeForthirdRecipient - thirdRecipientFee < ALLOWED_ERROR);
-
     }
 
     function testClaimRewardStakingChange() public {
@@ -411,13 +408,10 @@ contract InverseBondingCurveTest is Test {
 
         assertEq(otherRecipientFee, feePercent / 3 + feePercent / 6);
         assertEq(thirdRecipientFee, feePercent / 6);
-
     }
 
     function testLpTransfers() public {
-
         curveContract.addLiquidity{value: LIQUIDITY_2ETH_BEFOR_FEE}(recipient, 0);
-
 
         (uint256 reward,,,) = curveContract.rewardOf(recipient);
         assertEq(reward, 0);
@@ -448,7 +442,6 @@ contract InverseBondingCurveTest is Test {
         vm.startPrank(recipient);
         curveContract.transferFrom(otherRecipient, recipient, 2e18);
         vm.stopPrank();
-
 
         (uint256 senderLpReward2,,,) = curveContract.rewardOf(otherRecipient);
         (uint256 recipientLpReward2,,,) = curveContract.rewardOf(recipient);
@@ -522,7 +515,6 @@ contract InverseBondingCurveTest is Test {
         vm.startPrank(otherRecipient);
         tokenContract.approve(address(curveContract), 1e18);
         curveContract.stake(1e18);
-       
 
         (uint256 inverseTokenForLp, uint256 inverseTokenForStaking, uint256 reserveForLp, uint256 reserveForStaking) =
             curveContract.rewardOf(otherRecipient);

--- a/test/InverseBondingCurveFuzz.t.sol
+++ b/test/InverseBondingCurveFuzz.t.sol
@@ -70,7 +70,8 @@ contract InverseBondingCurveFuzzTest is Test {
     function testFuzz(uint256 additionalReserve, uint256 buyReserve) private {
         uint256 reserve = 1e21; // 1000
         uint256 supply = 5e24; //
-        uint256 price = 1e14; // 0.0001 ETH
+        uint256 price = 1e14;
+        // 0.0001 ETH
 
         additionalReserve = bound(additionalReserve, 0.001 ether, 1e4 ether);
         buyReserve = bound(buyReserve, 0.001 ether, 1e4 ether);


### PR DESCRIPTION
Found circular reference even use pre-calculated contract address to deploy and initialize, also because of dependency multi-call work directly, so create a deployer contract to deploy contracts and initialize in one transaction 