### PR TITLE
Fix TRST-M-5 When a user claims the first staker rewards, their previ…

### DIFF
--- a/src/InverseBondingCurve.sol
+++ b/src/InverseBondingCurve.sol
@@ -749,7 +749,7 @@ contract InverseBondingCurve is Initializable, UUPSUpgradeable, IInverseBondingC
     function _rewardFirstStaker(address account, FeeType feeType) private {
         FeeState storage state = _feeStates[uint256(feeType)];
         if (state.feeForFirstStaker > 0) {
-            state.pendingRewards[REWARD_STAKE][account] = state.feeForFirstStaker;
+            state.pendingRewards[REWARD_STAKE][account] += state.feeForFirstStaker;
             state.feeForFirstStaker = 0;
         }
     } 

--- a/test/InverseBondingCurve.t.sol
+++ b/test/InverseBondingCurve.t.sol
@@ -764,7 +764,7 @@ contract InverseBondingCurveTest is Test {
 
     function testRewardFirstStaker() public {
         uint256[2] memory valueRange = [uint256(0),uint256(0)];
-        uint256 buyLiquidity = 1e18;
+        uint256 buyLiquidity = 2e18;
 
         reserveToken.mint(recipient, LIQUIDITY_2ETH_BEFOR_FEE);
         reserveToken.transfer(address(curveContract), LIQUIDITY_2ETH_BEFOR_FEE);
@@ -799,6 +799,14 @@ contract InverseBondingCurveTest is Test {
         assertEqWithError(inverseTokenForStaking, accumulatedTokenFee);
         assertEqWithError(reserveForStaking, accumulatedReserveFee);
 
+        curveContract.unstake(otherRecipient, 1e18);
+
+        tokenContract.transfer(address(curveContract), 1e18);
+        curveContract.sellTokens(recipient, 1e18, valueRange, valueRange);
+
+        tokenContract.transfer(address(curveContract), 1e18);
+        curveContract.stake(otherRecipient, 1e18);
+
         uint256 reserveBalanceBefore = reserveToken.balanceOf(otherRecipient);
         uint256 tokenBalanceBefore = tokenContract.balanceOf(otherRecipient);
 
@@ -807,7 +815,7 @@ contract InverseBondingCurveTest is Test {
         uint256 reserveBalanceAfter = reserveToken.balanceOf(otherRecipient);
         uint256 tokenBalanceAfter = tokenContract.balanceOf(otherRecipient);
         assertEq(reserveBalanceAfter - reserveBalanceBefore, reserveForStaking);
-        assertEq(tokenBalanceAfter - tokenBalanceBefore, inverseTokenForStaking);
+        assertEq(tokenBalanceAfter - tokenBalanceBefore, inverseTokenForStaking + feePercent.divDown(3e18));
 
         vm.stopPrank();
     }


### PR DESCRIPTION
@ibjc There is a little change for event: TokenStaked, TokenUnstaked, add the recipient parameter to indicate the account to hold staking position or unstaked amount receiver. You may need to update frontend for the event log parse